### PR TITLE
Fix cloning the view's file and cursor

### DIFF
--- a/i3.kak
+++ b/i3.kak
@@ -13,7 +13,8 @@ define-command -hidden -params 1.. i3-new-impl %{
     i3_split="$1"
     shift
     # clone (same buffer, same line)
-    kakoune_args="-e 'execute-keys $@ :buffer <space> %val{buffile} <ret> %val{cursor_line} g'"
+    cursor="$kak_cursor_line.$kak_cursor_column"
+    kakoune_args="-e 'execute-keys $@ :buffer <space> $kak_buffile <ret> :select <space> $cursor,$cursor <ret>'"
     {
       # https://github.com/i3/i3/issues/1767
       i3-msg "split $i3_split"


### PR DESCRIPTION
In https://github.com/Delapouite/kakoune-i3/commit/e89277056ea1c64c4f5abfbb976a4d842221808e the %val{buffile} was moved to be evaluated in the newly created client. This commit makes the buffile and cursor come from the original client's view.